### PR TITLE
Update 0.0.1 md

### DIFF
--- a/versions/0.0.1.md
+++ b/versions/0.0.1.md
@@ -84,13 +84,13 @@ Here is an example of a properly formatted timestamp…
 
 | Name       | Description                     | Unit  |
 | ---------- | ------------------------------- | ----- |
-| red        | Level of red spectrum light     | PPF/s |
-| blue       | Level of blue spectrum light    | PPF/s |
-| green      | Level of green spectrum light   | PPF/s |
-| uv         | Level of ultraviolet light      | PPF/s |
-| infrared   | Level of infrared light         | PPF/s |
-| par        | Level of absorbable light       | PPF/s |
-| light      | Level of all spectrums of light | PPF/s |
+| red        | Level of red spectrum light     | PPF   | 
+| blue       | Level of blue spectrum light    | PPF   |
+| green      | Level of green spectrum light   | PPF   |
+| uv         | Level of ultraviolet light      | PPF   |
+| infrared   | Level of infrared light         | PPF   |
+| par        | Level of absorbable light       | PPF   |
+| light      | Level of all spectrums of light | PPF   |
 | red.d      | Level of red spectrum light     | PPFD  |
 | blue.d     | Level of blue spectrum light    | PPFD  |
 | green.d    | Level of green spectrum light   | PPFD  |


### PR DESCRIPTION
Changed PPF/s to PPF. 

Note--Although PPF is used interchangeably with umol/s, the standard unit of measurement is the latter: umol/s. I recommend the latter unit expression (umol/s) because it follows the other sensor unit expressions. PPFD of course factors in area in terms of m2, so: umol/m2/s.