### PR TITLE
Recommend to use RFC3339 for timestamp formatting

### DIFF
--- a/versions/master/README.md
+++ b/versions/master/README.md
@@ -43,13 +43,19 @@ The interpretation of error codes, including the text describing the error, will
 
 # Timestamps
 
-All monitoring data MUST be accompanied by a timestamp that includes year, month, day, hour, minute, second, and time zone. The format MUST be as follows…
+All monitoring data MUST be accompanied by a timestamp in the RFC3339 format.
 
-`[year]-[month]-[day]_[hour]-[min]-[sec]_[timezone]`
+`YYYY-MM-DDTHH:MM:SS[+8]`
 
-Here is an example of a properly formatted timestamp…
+Here is an example of a properly formatted timestamp in UTC:
 
-`2018-01-25_04-56-05_UTC`
+`2018-01-25T04:56:05Z`
+
+And the same time in the NZST timezone:
+
+`2018-01-25T04:56:05+12:00`
+
+See [http://pretty-rfc.herokuapp.com/RFC3339] for more information.
 
 # Common Structures
 Many concepts use the same data structures to report their essential information. Those structures are listed here.  

--- a/versions/master/README.md
+++ b/versions/master/README.md
@@ -45,7 +45,7 @@ The interpretation of error codes, including the text describing the error, will
 
 All monitoring data MUST be accompanied by a timestamp in the RFC3339 format.
 
-`YYYY-MM-DDTHH:MM:SS[+8]`
+`YYYY-MM-DDTHH:MM:SS[Z|-HH:MM|+HH:MM]`
 
 Here is an example of a properly formatted timestamp in UTC:
 


### PR DESCRIPTION
To make the API more palatable to developers, it would be nicer to use an existing and widely used open standard made for internet protocols.  For this reason I recommend switching to the RFC3339 standard. 

## golang

```go
tstamp := time.Now().Format(time.RFC3339)  // get the current time as an RFC3339 string
t, err := time.Parse(time.RFC3339, tstamp) // parse it to a time object
tstamp = t.Format(time.RFC3339)            // format the time object to an RFC3339 string

```
## ruby

```ruby
tstamp = DateTime.now.rfc3339(0)   # get the current time as an RFC3339 string
t = DateTime.rfc3339(tstamp)       # parse it to a DateTime object
tstamp = t.rfc3339(0)              # format the time DateTime object as a RFC3339 string
```
## python

```python
from pyrfc3339 import generate, parse
from datetime import datetime
tstamp = generate(datetime.utcnow())
t = parse(tstamp)
tstamp = generate(t)
```
